### PR TITLE
방문자수 집계 Ip 받아오는 코드 수정

### DIFF
--- a/middlewares/vistorCount_middleware.js
+++ b/middlewares/vistorCount_middleware.js
@@ -6,7 +6,7 @@ const redisCli = redisClient.v4;
 
 module.exports = (req, res, next) => {
   try {
-    const clientIp = req.ip;
+    const clientIp = req.headers["x-forwarded-for"];
     console.log("IP 주소 : ", clientIp);
 
     redisCli.PFADD(localDate, clientIp);

--- a/services/todolist.service.js
+++ b/services/todolist.service.js
@@ -180,12 +180,12 @@ class TodoListService {
   rankingGet = async () => {
     // 어제 날짜 - 자정으로 세팅
     const yesterday = new Date();
-    yesterday.setHours(yesterday.getHours() + 9);
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
 
     console.log("[+9] 메인 top5 - 어제 자정: ", yesterday);
     const yesterday2 = new Date();
+    yesterday2.setHours(yesterday2.getHours() + 9);
     yesterday2.setDate(yesterday2.getDate() - 1);
     yesterday2.setHours(0, 0, 0, 0);
     console.log("메인 top5 - 어제 자정: ", yesterday2);

--- a/services/todolist.service.js
+++ b/services/todolist.service.js
@@ -114,7 +114,7 @@ class TodoListService {
 
     console.log("상세 todo 조회 - 오늘 과거의 자정: ", today);
     const today2 = new Date();
-    today.setHours(today.getHours() + 9);
+    today2.setHours(today2.getHours() + 9);
     today2.setHours(0, 0, 0, 0);
     console.log("[+9]상세 todo 조회 - 오늘 과거의 자정: ", today2);
 
@@ -180,15 +180,15 @@ class TodoListService {
   rankingGet = async () => {
     // 어제 날짜 - 자정으로 세팅
     const yesterday = new Date();
+    yesterday.setHours(yesterday.getHours() + 9);
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
 
-    console.log("메인 top5 - 어제 자정: ", yesterday);
+    console.log("[+9] 메인 top5 - 어제 자정: ", yesterday);
     const yesterday2 = new Date();
-    yesterday2.setHours(yesterday2.getHours() + 9);
     yesterday2.setDate(yesterday2.getDate() - 1);
     yesterday2.setHours(0, 0, 0, 0);
-    console.log("[+9] 메인 top5 - 어제 자정: ", yesterday2);
+    console.log("메인 top5 - 어제 자정: ", yesterday2);
 
     const challenge = await Todo.findAll({
       where: {

--- a/services/todolist.service.js
+++ b/services/todolist.service.js
@@ -183,12 +183,12 @@ class TodoListService {
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
 
-    console.log("[+9] 메인 top5 - 어제 자정: ", yesterday);
+    console.log("메인 top5 - 어제 자정: ", yesterday);
     const yesterday2 = new Date();
     yesterday2.setHours(yesterday2.getHours() + 9);
     yesterday2.setDate(yesterday2.getDate() - 1);
     yesterday2.setHours(0, 0, 0, 0);
-    console.log("메인 top5 - 어제 자정: ", yesterday2);
+    console.log("[+9] 메인 top5 - 어제 자정: ", yesterday2);
 
     const challenge = await Todo.findAll({
       where: {


### PR DESCRIPTION
방문자수 집계를 위해 ip 주소를 받아오려 했으나 nginx 로드밸런싱으로 인해 nginx 서버의 ip로만 받아와지는 문제 발생
-> nginx 리버스 프록시 설정에 x-forwarded-for를 헤더에 담아 보내는 걸로 수정하여 해결